### PR TITLE
Fix overly aggressive connection validation

### DIFF
--- a/Assets/WebSocketServer/WebSocketProtocol.cs
+++ b/Assets/WebSocketServer/WebSocketProtocol.cs
@@ -75,7 +75,7 @@ namespace WebSocketServer {
             }
 
             // Must have a Connection: Upgrade
-            if (!request.headers.ContainsKey("Connection") || !String.Equals(request.headers["Connection"], "Upgrade")) {
+            if (!request.headers.ContainsKey("Connection") || request.headers["Connection"].IndexOf("Upgrade") == -1) {
                 Debug.Log("Request does not have Connection: Upgrade.");
                 return false;
             }


### PR DESCRIPTION
Some clients (eg Mozilla Firefox) send multiple, comma separated values on the `Connection` header (`keep-alive` and `Upgrade`). This PR fixes inappropriate rejection of those connection requests.

![image](https://user-images.githubusercontent.com/284311/175838624-823db207-8c91-41db-9452-097d00a121cf.png)
